### PR TITLE
Fix encoding issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,7 @@ indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.bat]
+charset = cp850
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bat	text eol=crlf working-tree-encoding=windows-1252

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.bat	text eol=crlf working-tree-encoding=windows-1252
+*.bat	text eol=crlf working-tree-encoding=cp850

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,8 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "[bat]": {
+        "files.encoding": "cp850"
+    }
 }

--- a/scripts/import_dvv.bat
+++ b/scripts/import_dvv.bat
@@ -1,8 +1,13 @@
 @echo off
 
+REM Vaihdetaan terminaalin code page UTF-8:ksi
+CHCP 65001
+REM Kerrotaan Postgresille myös että terminaalin encoding on UTF-8
+SET PGCLIENTENCODING=UTF8
+
 SET HOST=localhost
 SET PORT=5435
-SET DB_NAME=ymparisto_db
+SET DB_NAME=jkr
 SET USER=jkr_admin
 REM Määritä salasana %APPDATA%\postgresql\pgpass.conf tiedostossa
 

--- a/scripts/import_posti.bat
+++ b/scripts/import_posti.bat
@@ -1,8 +1,13 @@
 @echo off
 
+REM Vaihdetaan terminaalin code page UTF-8:ksi
+CHCP 65001
+REM Kerrotaan Postgresille myös että terminaalin encoding on UTF-8
+SET PGCLIENTENCODING=UTF8
+
 SET HOST=localhost
 SET PORT=5435
-SET DB_NAME=ymparisto_db
+SET DB_NAME=jkr
 SET USER=jkr_admin
 REM Määritä salasana %APPDATA%\postgresql\pgpass.conf tiedostossa
 


### PR DESCRIPTION
- Batch files must always be saved as ANSI/win1252 encoding
- Change terminal encoding and pg-client-encoding to UTF-8 since our sql-file is saved utf-8