### PR TITLE
Lahti: loppupäivämäärän lisäys DVV-päivityksen yhteydessä päättyville kohteille

### DIFF
--- a/jkrimporter/providers/db/services/kohde.py
+++ b/jkrimporter/providers/db/services/kohde.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timedelta
 import re
 from collections import defaultdict
 from functools import lru_cache
@@ -854,6 +855,11 @@ def update_or_create_kohde_from_buildings(
     # Update kohde to be valid for the whole import period
     if not poimintapvm or (kohde.alkupvm and poimintapvm < kohde.alkupvm):
         kohde.alkupvm = poimintapvm
+
+    # Reset end date if using poimintapvm (kohde is still active)
+    if poimintapvm and kohde.loppupvm == poimintapvm - timedelta(days=1):
+        kohde.loppupvm = None
+
     return kohde
 
 

--- a/tests/test_data_import.py
+++ b/tests/test_data_import.py
@@ -43,6 +43,16 @@ def test_import_dvv_kohteet(engine, datadir):
     # Kohteiden lkm
     assert session.query(func.count(Kohde.id)).scalar() == 5
 
+    # Perusmaksurekisteristä luodulla kohteella Asunto Oy Kahden Laulumuisto on loppupäivämäärä
+    kohde_nimi_filter = Kohde.nimi == 'Asunto Oy Kahden Laulumuisto'
+    loppu_pvm_filter = Kohde.loppupvm == func.to_date('2100-01-01', 'YYYY-MM-DD')
+    kohde_id = session.query(Kohde.id).filter(kohde_nimi_filter).filter(loppu_pvm_filter).scalar()
+    assert kohde_id is not None
+
+    # Muilla kohteilla ei loppupäivämäärää
+    loppu_pvm_filter = Kohde.loppupvm != None
+    assert session.query(func.count(Kohde.id)).filter(loppu_pvm_filter).scalar() == 1
+
     # Kaikilla kohteilla vähintään yksi omistaja
     kohteet = select(Kohde.id)
     kohteet_having_omistaja = \
@@ -81,6 +91,22 @@ def test_update_dvv_kohteet(engine):
 
     # Kohteiden lkm
     assert session.query(func.count(Kohde.id)).scalar() == 6
+
+    # Perusmaksurekisteristä luodun kohteen Asunto Oy Kahden Laulumuisto loppupäivämäärä ei ole muuttunut
+    kohde_nimi_filter = Kohde.nimi == 'Asunto Oy Kahden Laulumuisto'
+    loppu_pvm_filter = Kohde.loppupvm == func.to_date('2100-01-01', 'YYYY-MM-DD')
+    kohde_id = session.query(Kohde.id).filter(kohde_nimi_filter).filter(loppu_pvm_filter).scalar()
+    assert kohde_id is not None
+
+    # Päättyneelle kohteelle Kemp asetettu loppupäivämäärä
+    kohde_nimi_filter = Kohde.nimi == 'Kemp'
+    loppu_pvm_filter = Kohde.loppupvm == func.to_date('2023-01-30', 'YYYY-MM-DD')
+    kohde_id = session.query(Kohde.id).filter(kohde_nimi_filter).filter(loppu_pvm_filter).scalar()
+    assert kohde_id is not None
+
+    # Muilla kohteilla ei loppupäivämäärää
+    loppu_pvm_filter = Kohde.loppupvm != None
+    assert session.query(func.count(Kohde.id)).filter(loppu_pvm_filter).scalar() == 2
 
     # Uudessa kohteessa Kyykoski osapuolina Granström (omistaja) ja Kyykoski (uusi asukas)
     kohde_filter = and_(Kohde.nimi == 'Kyykoski', Kohde.alkupvm == '2023-01-31')


### PR DESCRIPTION
Asetetaan loppupäivämäärä niille kohteille, jotka päättyvät DVV-aineiston päivityksen seurauksena.

- Asetetaan loppupäivämääräksi DVV-aineiston poimintapäivämäärää edeltävä päivä.
- Lisätty testit.