### PR TITLE
Lahti: jätetään kohteen loppupäivämäärä päivittämättä kuljetusten yhteydessä

### DIFF
--- a/jkrimporter/cli/jkr.py
+++ b/jkrimporter/cli/jkr.py
@@ -73,12 +73,17 @@ def import_data(
     luo_uudet: bool = typer.Option(
         False,
         "--luo_uudet",
-        help="Luo puuttuvat uudet kohteet tästä datasta."
+        help="Luo puuttuvat uudet kohteet tästä datasta.",
     ),
-    ala_paivita: bool = typer.Option(
+    ala_paivita_yhteystietoja: bool = typer.Option(
         False,
-        "--ala_paivita",
-        help="Älä päivitä yhteystietoja tai kohteen voimassaoloaikaa tästä datasta.",
+        "--ala_paivita_yhteystietoja",
+        help="Älä päivitä yhteystietoja tästä datasta.",
+    ),
+    ala_paivita_kohdetta:  bool = typer.Option(
+        True,
+        "--ala_paivita_kohdetta",
+        help="Älä päivitä kohteen voimassaoloaikaa tästä datasta.",
     ),
     alkupvm: str = typer.Argument(None, help="Importoitavan datan alkupvm"),
     loppupvm: str = typer.Argument(None, help="Importoitavan datan loppupvm"),
@@ -96,17 +101,12 @@ def import_data(
         alkupvm = parse_date_string(alkupvm)
     if loppupvm:
         loppupvm = parse_date_string(loppupvm)
-    if tiedontuottajatunnus == "HKO":
-        ala_paivita = True
-        if not alkupvm or not loppupvm:
-            typer.echo("Nokian importin yhteydessä päivämäärät ovat pakolliset")
-            raise typer.Exit()
 
     translator = provider.Translator(data, tiedontuottajatunnus)
     jkr_data = translator.as_jkr_data(alkupvm, loppupvm)
     print('writing to db...')
     db = DbProvider()
-    db.write(jkr_data, tiedontuottajatunnus, not luo_uudet, ala_paivita)
+    db.write(jkr_data, tiedontuottajatunnus, not luo_uudet, ala_paivita_yhteystietoja, ala_paivita_kohdetta)
 
     print("VALMIS!")
 

--- a/jkrimporter/providers/db/dbprovider.py
+++ b/jkrimporter/providers/db/dbprovider.py
@@ -183,14 +183,15 @@ def import_asiakastiedot(
     loppupvm: Optional[datetime.date],
     urakoitsija: Tiedontuottaja,
     do_create: bool,
-    do_update: bool,
+    do_update_contact: bool,
+    do_update_kohde: bool,
     prt_counts: Dict[str, IntervalCounter],
     kitu_counts: Dict[str, IntervalCounter],
     address_counts: Dict[str, IntervalCounter],
 ):
 
     kohde = find_and_update_kohde(
-        session, asiakas, do_create, do_update, prt_counts, kitu_counts, address_counts
+        session, asiakas, do_create, do_update_kohde, prt_counts, kitu_counts, address_counts
     )
     if not kohde:
         print(f"Could not find kohde for asiakas {asiakas}, skipping...")
@@ -198,7 +199,7 @@ def import_asiakastiedot(
 
     # Update osapuolet from the same tiedontuottaja. This function will not
     # touch data from other tiedontuottajat.
-    create_or_update_haltija_osapuoli(session, kohde, asiakas, do_update)
+    create_or_update_haltija_osapuoli(session, kohde, asiakas, do_update_contact)
 
     update_sopimukset_for_kohde(session, kohde, asiakas, loppupvm, urakoitsija)
     insert_kuljetukset(
@@ -261,7 +262,8 @@ class DbProvider:
         jkr_data: JkrData,
         tiedontuottaja_lyhenne: str,
         ala_luo: bool,
-        ala_paivita: bool,
+        ala_paivita_yhteystietoja: bool,
+        ala_paivita_kohdetta: bool,
     ):
         try:
             print(len(jkr_data.asiakkaat))
@@ -317,7 +319,8 @@ class DbProvider:
                         jkr_data.loppupvm,
                         tiedontuottajat[urakoitsija_tunnus],
                         not ala_luo,
-                        not ala_paivita,
+                        not ala_paivita_yhteystietoja,
+                        not ala_paivita_kohdetta,
                         prt_counts,
                         kitu_counts,
                         address_counts,


### PR DESCRIPTION
Lisää option jättää kohteen loppupäivämäärä päivittämättä kuljetustietojen lisäämisen yhteydessä, vaikka yhteystiedot päivitettäisiin. Asetettu oletukseksi, ettei loppupäivämäärää päivitetä.