### PR TITLE
Lahti: päivitetään huoneistojen lukumäärä

### DIFF
--- a/scripts/update_huoneistomaara.bat
+++ b/scripts/update_huoneistomaara.bat
@@ -1,0 +1,31 @@
+@echo off
+
+REM Tarkistetaan, että on annettu polku xlsx-tiedostoon
+ IF "%~1"=="" (
+    echo Anna polku xlsx-tiedostoon, joka sisältää huoneistomäärät
+    exit /b 1
+)
+
+REM Vaihdetaan terminaalin code page UTF-8:ksi
+CHCP 65001
+REM Kerrotaan Postgresille myäs että terminaalin encoding on UTF-8
+SET PGCLIENTENCODING=UTF8
+
+SET EXCEL_FILE=%~1
+SET HOST=<palvelimen nimi>
+SET PORT=<tietokantaportti>
+SET DB_NAME=<tietokannan_nimi>
+SET USER=<kayttajatunnus>
+REM Määritä salasana %APPDATA%\postgresql\pgpass.conf tiedostossa
+
+REM Määritä polku QGISin psql-asennukseen. Esim. "C:\\Program Files\\QGIS 3.30.2\\bin".
+SET PSQL_PATH="<Tiedostopolku QGISin bin kansioon>"
+
+REM Määritä polku QGISin ogr2ogr-asennukseen. Esim. "C:\\Program Files\\QGIS 3.30.2\\bin".
+SET OGR2OGR_PATH="<Tiedostopolku QGISin bin kansioon>"
+
+ECHO Luetaan huoneistomäärät
+%OGR2OGR_PATH%\\ogr2ogr -f PostgreSQL -overwrite -progress PG:"host=%HOST% port=%PORT% dbname=%DB_NAME% user=%USER% ACTIVE_SCHEMA=jkr_dvv" -nln huoneistomaara %EXCEL_FILE% "Huoneistolkm"
+
+ECHO Päivitetään huoneistomäärät rakennus-tauluun
+%PSQL_PATH%\\psql -h %HOST% -p %PORT% -d %DB_NAME% -U %USER% -f "update_huoneistomaara.sql"

--- a/scripts/update_huoneistomaara.sql
+++ b/scripts/update_huoneistomaara.sql
@@ -1,0 +1,4 @@
+UPDATE jkr.rakennus
+SET huoneistomaara = huoneistomaara.i_huoneistojen_lkm
+FROM jkr_dvv.huoneistomaara
+WHERE rakennus.prt = huoneistomaara.c_vtj_prt;


### PR DESCRIPTION
Skripti huoneistojen lukumäärän päivittämiseksi rakennus-tauluun.

- lukee huoneistojen lukumäärät parametrina annettavasta xlsx-tiedostosta
- päivittää rakennus-taulun huoneistomaara-kentän PRT:n perusteella