### PR TITLE
Lahti: biojätteen velvoitetarkastelu

### DIFF
--- a/db/migrations/velvoitteet/R__z_Insert_velvoitemalli.sql
+++ b/db/migrations/velvoitteet/R__z_Insert_velvoitemalli.sql
@@ -107,5 +107,50 @@ VALUES
         (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
         '2022-1-1',
         'Sekajäte kunnossa'
+    ),
+    (
+        13,
+        'Biojäte',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_bio_puuttuu',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Biojäte'),
+        '2022-1-1',
+        'Biojäte puuttuu'
+    ),
+    (
+        14,
+        'Biojäte',
+        'v_enint_4_huoneistoa_biojatteen_erilliskeraysalue',
+        'kohteet_joilla_bio_puuttuu_ei_kompostointia',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Biojäte'),
+        '2022-1-1',
+        'Biojäte puuttuu'
+    ),
+    (
+        15,
+        'Biojäte',
+        'v_erilliskeraysalueet',
+        'kohteet_joilla_bio_0_tai_yli_4_vk',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Biojäte'),
+        '2022-1-1',
+        'Biojäte väärä tyhjennysväli'
+    ),
+    (
+        16,
+        'Biojäte',
+        'v_erilliskeraysalueet',
+        'kohteet_joilla_bio_enint_4_vk',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Biojäte'),
+        '2022-1-1',
+        'Biojäte kunnossa'
+    ),
+    (
+        17,
+        'Biojäte',
+        'v_enint_4_huoneistoa_biojatteen_erilliskeraysalue',
+        'kohteet_joilla_kompostointi_voimassa',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Biojäte'),
+        '2022-1-1',
+        'Biojäte kunnossa'
     )
 ON CONFLICT DO NOTHING;

--- a/db/migrations/velvoitteet/V2.36.7__Add_erilliskeraysalueet.sql
+++ b/db/migrations/velvoitteet/V2.36.7__Add_erilliskeraysalueet.sql
@@ -1,0 +1,34 @@
+CREATE OR REPLACE VIEW jkr.v_enint_4_huoneistoa_biojatteen_erilliskeraysalue AS (
+    SELECT DISTINCT k.*
+    FROM jkr.kohde k
+    JOIN jkr.kohteen_rakennukset kr ON kr.kohde_id = k.id
+    JOIN jkr.rakennus r ON r.id = kr.rakennus_id
+    JOIN jkr.taajama t ON ST_Contains(t.geom, r.geom)
+    WHERE t.vaesto_lkm >= 10000
+    AND (
+        SELECT SUM(COALESCE((rak.huoneistomaara)::integer, 1))
+        FROM jkr.kohteen_rakennukset kkr
+        JOIN jkr.rakennus rak ON rak.id = kkr.rakennus_id
+        WHERE kkr.kohde_id = k.id
+    ) <= 4
+);
+
+CREATE OR REPLACE VIEW jkr.v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue AS (
+    SELECT DISTINCT k.*
+    FROM jkr.kohde k
+    JOIN jkr.kohteen_rakennukset kr ON kr.kohde_id = k.id
+    JOIN jkr.rakennus r ON r.id = kr.rakennus_id
+    JOIN jkr.taajama t ON ST_Contains(t.geom, r.geom)
+    AND (
+        SELECT SUM(COALESCE((rak.huoneistomaara)::integer, 1))
+        FROM jkr.kohteen_rakennukset kkr
+        JOIN jkr.rakennus rak ON rak.id = kkr.rakennus_id
+        WHERE kkr.kohde_id = k.id
+    ) >= 5
+);
+
+CREATE OR REPLACE VIEW jkr.v_erilliskeraysalueet AS (
+    SELECT * FROM jkr.v_enint_4_huoneistoa_biojatteen_erilliskeraysalue
+    UNION ALL
+    SELECT * FROM jkr.v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue
+);

--- a/db/migrations/velvoitteet/V2.36.8__Add_biojate.sql
+++ b/db/migrations/velvoitteet/V2.36.8__Add_biojate.sql
@@ -26,6 +26,12 @@ WHERE
             WHERE sk.sopimustyyppi_id = st.id
             AND st.selite = 'Kimppasopimus'
         )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Biojäte'
+        )
         AND sk.voimassaolo @> $1
         AND EXISTS (
             SELECT 1
@@ -70,6 +76,12 @@ WHERE
             FROM jkr_koodistot.sopimustyyppi st
             WHERE sk.sopimustyyppi_id = st.id
             AND st.selite = 'Kimppasopimus'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Biojäte'
         )
         AND sk.voimassaolo @> $1
         AND EXISTS (
@@ -125,6 +137,12 @@ WHERE
             FROM jkr_koodistot.sopimustyyppi st
             WHERE sk.sopimustyyppi_id = st.id
             AND st.selite = 'Kimppasopimus'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Biojäte'
         )
         AND sk.voimassaolo @> $1
         AND EXISTS (
@@ -182,6 +200,12 @@ WHERE
             FROM jkr_koodistot.sopimustyyppi st
             WHERE sk.sopimustyyppi_id = st.id
             AND st.selite = 'Kimppasopimus'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Biojäte'
         )
         AND sk.voimassaolo @> $1
         AND EXISTS (

--- a/db/migrations/velvoitteet/V2.36.8__Add_biojate.sql
+++ b/db/migrations/velvoitteet/V2.36.8__Add_biojate.sql
@@ -1,0 +1,207 @@
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_bio_puuttuu(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Biojäte'
+        )
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Biojäte'
+            )   
+        )        
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_bio_puuttuu_ei_kompostointia(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Biojäte'
+        )
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Biojäte'
+            )   
+        )        
+    )
+    AND k.id NOT IN (
+        SELECT kohteet_joilla_kompostointi_voimassa
+        FROM jkr.kohteet_joilla_kompostointi_voimassa($1)
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_bio_0_tai_yli_4_vk(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Biojäte'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.tyhjennysvali tv
+            WHERE tv.sopimus_id = s.id
+            AND (tv.tyhjennysvali = 0 OR tv.tyhjennysvali > 4)
+        )
+    )
+    OR EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Biojäte'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.tyhjennysvali tv
+                WHERE tv.sopimus_id = ski.id
+                AND (tv.tyhjennysvali = 0 OR tv.tyhjennysvali > 4)
+            )
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_bio_enint_4_vk(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Biojäte'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.tyhjennysvali tv
+            WHERE tv.sopimus_id = s.id
+            AND tv.tyhjennysvali > 0 AND tv.tyhjennysvali <= 4
+        )
+    )
+    OR EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Biojäte'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.tyhjennysvali tv
+                WHERE tv.sopimus_id = ski.id
+                AND tv.tyhjennysvali > 0 AND tv.tyhjennysvali <= 4
+            )
+        )
+    );
+$$
+LANGUAGE SQL STABLE;


### PR DESCRIPTION
Lisätään migraatiot biojätteen velvoitetarkastelua varten määrittely-excelin rivien 16-20 mukaisesti.

- luodaan näkymät kohteista, joita biojätteen tarkastelu koskee
- luodaan täyttymissäännöt neljälle ehtojoukolle
- lisätään malli jokaiselle ehtojoukolle velvoitemallien tauluun

Ei sisällä testejä, kaikkia tapauksia testattu tietokannassa pintapuolisesti.
