### PR TITLE
Lahti: kartongin velvoitetarkastelu

### DIFF
--- a/db/migrations/velvoitteet/R__z_Insert_velvoitemalli.sql
+++ b/db/migrations/velvoitteet/R__z_Insert_velvoitemalli.sql
@@ -179,5 +179,32 @@ VALUES
         (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Muovi'),
         '2022-1-1',
         'Muovi kunnossa'
+    ),
+    (
+        21,
+        'Kartonki',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_kartonki_puuttuu',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Kartonki'),
+        '2022-1-1',
+        'Kartonkipakkaus puuttuu'
+    ),
+    (
+        22,
+        'Kartonki',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_kartonki_yli_12_vk',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Kartonki'),
+        '2022-1-1',
+        'Kartonkipakkaus väärä tyhjennysväli'
+    ),
+    (
+        23,
+        'Kartonki',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_kartonki_enintaan_12_vk',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Kartonki'),
+        '2022-1-1',
+        'Kartonkipakkaus kunnossa'
     )
 ON CONFLICT DO NOTHING;

--- a/db/migrations/velvoitteet/V2.36.11__Add_kartonki.sql
+++ b/db/migrations/velvoitteet/V2.36.11__Add_kartonki.sql
@@ -1,0 +1,176 @@
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_kartonki_puuttuu(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Kartonki'
+        )
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Kartonki'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Kartonki'
+            )   
+        )        
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_kartonki_yli_12_vk(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Kartonki'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.tyhjennysvali tv
+            WHERE tv.sopimus_id = s.id
+            AND tv.tyhjennysvali > 12
+        )
+    )
+    OR EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Kartonki'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Kartonki'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.tyhjennysvali tv
+                WHERE tv.sopimus_id = ski.id
+                AND tv.tyhjennysvali > 12
+            )
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_kartonki_enintaan_12_vk(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Kartonki'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.tyhjennysvali tv
+            WHERE tv.sopimus_id = s.id
+            AND tv.tyhjennysvali > 0 AND tv.tyhjennysvali <= 12
+        )
+    )
+    OR EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Kartonki'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Kartonki'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.tyhjennysvali tv
+                WHERE tv.sopimus_id = ski.id
+                AND tv.tyhjennysvali > 0 AND tv.tyhjennysvali <= 12
+            )
+        )
+    );
+$$
+LANGUAGE SQL STABLE;


### PR DESCRIPTION
Lisätään migraatiot kartongin velvoitetarkastelua varten määrittely-excelin mukaisesti.

- luodaan näkymät kohteista, joita tarkastelu koskee
- luodaan täyttymissäännöt kolmelle ehtojoukolle
- lisätään malli jokaiselle ehtojoukolle velvoitemallien tauluun

Ei sisällä testejä, kaikkia tapauksia testattu tietokannassa pintapuolisesti.
