### PR TITLE
Lahti: lisää velvoiteyhteenvedot

### DIFF
--- a/db/migrations/velvoitteet/R__z_Insert_velvoitemalli.sql
+++ b/db/migrations/velvoitteet/R__z_Insert_velvoitemalli.sql
@@ -260,5 +260,149 @@ VALUES
         (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Metalli'),
         '2022-1-1',
         'Metalli kunnossa'
+    ),
+    (
+        30,
+        'Velvoiteyhteenveto',
+        'v_ei_erilliskeraysalueet',
+        'kohteet_joilla_seka_ok',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto jätteenkuljetus kunnossa'
+    ),
+    (
+        31,
+        'Velvoiteyhteenveto',
+        'v_enint_4_huoneistoa_biojatteen_erilliskeraysalue',
+        'kohteet_joilla_seka_ok_kompostointi_voimassa',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto jätteenkuljetus kunnossa'
+    ),
+    (
+        32,
+        'Velvoiteyhteenveto',
+        'v_enint_4_huoneistoa_biojatteen_erilliskeraysalue',
+        'kohteet_joilla_seka_ok_bio_enint_4',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto jätteenkuljetus kunnossa'
+    ),
+    (
+        33,
+        'Velvoiteyhteenveto',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_seka_ok_bio_enint_4_muut_voimassa',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto jätteenkuljetus kunnossa'
+    ),
+    (
+        34,
+        'Velvoiteyhteenveto',
+        'kohde',
+        'kohteet_joilla_seka_puuttuu',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto ei jätehuoltoa'
+    ),
+    (
+        35,
+        'Velvoiteyhteenveto',
+        'v_erilliskeraysalueet',
+        'kohteet_joilla_seka_ok_bio_puuttuu',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto biojäte puuttuu'
+    ),
+    (
+        36,
+        'Velvoiteyhteenveto',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_muovi_enintaan_12_vk',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto pakkausjäte puutteellinen'
+    ),
+    (
+        37,
+        'Velvoiteyhteenveto',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_seka_ok_bio_enint_4_metalli_puuttuu',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto pakkausjäte puutteellinen'
+    ),
+    (
+        38,
+        'Velvoiteyhteenveto',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_seka_ok_bio_enint_4_lasi_puuttuu',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto pakkausjäte puutteellinen'
+    ),
+    (
+        39,
+        'Velvoiteyhteenveto',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_seka_ok_bio_enint_4_muovi_puuttuu',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto pakkausjäte puutteellinen'
+    ),
+    (
+        40,
+        'Velvoiteyhteenveto',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_seka_vaara_tvali_muut_voimassa',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto väärä tyhjennysväli sekajäte'
+    ),
+    (
+        41,
+        'Velvoiteyhteenveto',
+        'v_enint_4_huoneistoa_biojatteen_erilliskeraysalue',
+        'kohteet_joilla_seka_vaara_tvali_bio_voimassa',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto väärä tyhjennysväli sekajäte'
+    ),
+    (
+        42,
+        'Velvoiteyhteenveto',
+        'v_enint_4_huoneistoa_biojatteen_erilliskeraysalue',
+        'kohteet_joilla_seka_vaara_tvali_kompostointi_voimassa',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto väärä tyhjennysväli sekajäte'
+    ),
+    (
+        43,
+        'Velvoiteyhteenveto',
+        'v_ei_erilliskeraysalueet',
+        'kohteet_joilla_seka_vaara_tvali',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Sekajäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto väärä tyhjennysväli sekajäte'
+    ),
+    (
+        44,
+        'Velvoiteyhteenveto',
+        'v_enint_4_huoneistoa_biojatteen_erilliskeraysalue',
+        'kohteet_joilla_bio_vaara_tvali_seka_voimassa',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Biojäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto väärä tyhjennysväli biojäte'
+    ),
+    (
+        45,
+        'Velvoiteyhteenveto',
+        'v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue',
+        'kohteet_joilla_bio_vaara_tvali_muut_voimassa',
+        (SELECT id FROM jkr_koodistot.jatetyyppi WHERE selite = 'Biojäte'),
+        '2022-1-1',
+        'Velvoiteyhteenveto väärä tyhjennysväli biojäte'
     )
 ON CONFLICT DO NOTHING;

--- a/db/migrations/velvoitteet/V2.36.14__Add_ulkopuoliset_alueet.sql
+++ b/db/migrations/velvoitteet/V2.36.14__Add_ulkopuoliset_alueet.sql
@@ -1,0 +1,39 @@
+CREATE OR REPLACE VIEW jkr.v_enint_4_huoneistoa_ei_biojatteen_erilliskeraysalue AS (
+    SELECT DISTINCT k.*
+    FROM jkr.kohde k
+    JOIN jkr.kohteen_rakennukset kr ON kr.kohde_id = k.id
+    JOIN jkr.rakennus r ON r.id = kr.rakennus_id
+    WHERE
+        k.id NOT IN (
+            SELECT ke.id FROM jkr.v_enint_4_huoneistoa_biojatteen_erilliskeraysalue ke
+        ) 
+        AND (
+            SELECT SUM(COALESCE((rak.huoneistomaara)::integer, 1))
+            FROM jkr.kohteen_rakennukset kkr
+            JOIN jkr.rakennus rak ON rak.id = kkr.rakennus_id
+            WHERE kkr.kohde_id = k.id
+        ) <= 4
+);
+
+CREATE OR REPLACE VIEW jkr.v_vah_5_huoneistoa_ei_hyotyjatteen_erilliskeraysalue AS (
+    SELECT DISTINCT k.*
+    FROM jkr.kohde k
+    JOIN jkr.kohteen_rakennukset kr ON kr.kohde_id = k.id
+    JOIN jkr.rakennus r ON r.id = kr.rakennus_id
+    WHERE
+        k.id NOT IN (
+            SELECT ke.id FROM jkr.v_vah_5_huoneistoa_hyotyjatteen_erilliskeraysalue ke
+        ) 
+        AND (
+            SELECT SUM(COALESCE((rak.huoneistomaara)::integer, 1))
+            FROM jkr.kohteen_rakennukset kkr
+            JOIN jkr.rakennus rak ON rak.id = kkr.rakennus_id
+            WHERE kkr.kohde_id = k.id
+        ) >= 5
+);
+
+CREATE OR REPLACE VIEW jkr.v_ei_erilliskeraysalueet AS (
+    SELECT * FROM jkr.v_enint_4_huoneistoa_ei_biojatteen_erilliskeraysalue
+    UNION ALL
+    SELECT * FROM jkr.v_vah_5_huoneistoa_ei_hyotyjatteen_erilliskeraysalue
+);

--- a/db/migrations/velvoitteet/V2.36.15__Add_velvoiteyhteenvedot.sql
+++ b/db/migrations/velvoitteet/V2.36.15__Add_velvoiteyhteenvedot.sql
@@ -1,0 +1,1320 @@
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_ok(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_alle_4_vk
+            FROM jkr.kohteet_joilla_seka_alle_4_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_bio_on
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_bio_on($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_kompostointi_ok
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_kompostointi_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok($1)
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_ok_kompostointi_voimassa(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_alle_4_vk
+            FROM jkr.kohteet_joilla_seka_alle_4_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_bio_on
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_bio_on($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_kompostointi_ok
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_kompostointi_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok($1)
+        )
+    )
+    AND k.id IN (
+        SELECT kohteet_joilla_kompostointi_voimassa
+        FROM jkr.kohteet_joilla_kompostointi_voimassa($1)
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_ok_bio_enint_4(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_alle_4_vk
+            FROM jkr.kohteet_joilla_seka_alle_4_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_bio_on
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_bio_on($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_kompostointi_ok
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_kompostointi_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok($1)
+        )
+    )
+    AND k.id IN (
+        SELECT kohteet_joilla_bio_enint_4_vk
+        FROM jkr.kohteet_joilla_bio_enint_4_vk($1)
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_ok_bio_enint_4_muut_voimassa(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_alle_4_vk
+            FROM jkr.kohteet_joilla_seka_alle_4_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_bio_on
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_bio_on($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_kompostointi_ok
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_kompostointi_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok($1)
+        )
+    )
+    AND k.id IN (
+        SELECT kohteet_joilla_bio_enint_4_vk
+        FROM jkr.kohteet_joilla_bio_enint_4_vk($1)
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Kartonki'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Kartonki'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Kartonki'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Metalli'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Metalli'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Metalli'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Lasi'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Lasi'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Lasi'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Muovi'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Muovi'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Muovi'
+                )   
+            )
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_ok_bio_puuttuu(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_alle_4_vk
+            FROM jkr.kohteet_joilla_seka_alle_4_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_bio_on
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_bio_on($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_kompostointi_ok
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_kompostointi_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok($1)
+        )
+    )
+    AND k.id IN (
+        SELECT kohteet_joilla_bio_puuttuu
+        FROM jkr.kohteet_joilla_bio_puuttuu($1)
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_ok_bio_enint_4_kartonki_puuttuu(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_alle_4_vk
+            FROM jkr.kohteet_joilla_seka_alle_4_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_bio_on
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_bio_on($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_kompostointi_ok
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_kompostointi_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok($1)
+        )
+    )
+    AND k.id IN (
+        SELECT kohteet_joilla_bio_enint_4_vk
+        FROM jkr.kohteet_joilla_bio_enint_4_vk($1)
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Kartonki'
+        )
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Kartonki'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Kartonki'
+            )   
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_ok_bio_enint_4_metalli_puuttuu(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_alle_4_vk
+            FROM jkr.kohteet_joilla_seka_alle_4_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_bio_on
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_bio_on($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_kompostointi_ok
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_kompostointi_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok($1)
+        )
+    )
+    AND k.id IN (
+        SELECT kohteet_joilla_bio_enint_4_vk
+        FROM jkr.kohteet_joilla_bio_enint_4_vk($1)
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Metalli'
+        )
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Metalli'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Metalli'
+            )   
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_ok_bio_enint_4_lasi_puuttuu(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_alle_4_vk
+            FROM jkr.kohteet_joilla_seka_alle_4_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_bio_on
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_bio_on($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_kompostointi_ok
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_kompostointi_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok($1)
+        )
+    )
+    AND k.id IN (
+        SELECT kohteet_joilla_bio_enint_4_vk
+        FROM jkr.kohteet_joilla_bio_enint_4_vk($1)
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Lasi'
+        )
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Lasi'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Lasi'
+            )   
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_ok_bio_enint_4_muovi_puuttuu(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_alle_4_vk
+            FROM jkr.kohteet_joilla_seka_alle_4_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_bio_on
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_bio_on($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_enint_16_vk_kompostointi_ok
+            FROM jkr.kohteet_joilla_seka_enint_16_vk_kompostointi_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_kompostointi_ok_pidentava_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_bio_on_pidentava_ok($1)
+        )
+    )
+    AND k.id IN (
+        SELECT kohteet_joilla_bio_enint_4_vk
+        FROM jkr.kohteet_joilla_bio_enint_4_vk($1)
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus s
+        WHERE s.kohde_id = k.id
+        AND s.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE s.jatetyyppi_id = jt.id
+            AND jt.selite = 'Muovi'
+        )
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM jkr.sopimus sk
+        WHERE sk.kohde_id = k.id
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.sopimustyyppi st
+            WHERE sk.sopimustyyppi_id = st.id
+            AND st.selite = 'Kimppasopimus'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM jkr_koodistot.jatetyyppi jt
+            WHERE sk.jatetyyppi_id = jt.id
+            AND jt.selite = 'Muovi'
+        )
+        AND sk.voimassaolo @> $1
+        AND EXISTS (
+            SELECT 1
+            FROM jkr.sopimus ski
+            WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+            AND ski.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE ski.jatetyyppi_id = jt.id
+                AND jt.selite = 'Muovi'
+            )   
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_vaara_tvali_muut_voimassa(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_4_vk_ei_bio
+            FROM jkr.kohteet_joilla_seka_yli_4_vk_ei_bio($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_0_tai_yli_16_vk
+            FROM jkr.kohteet_joilla_seka_0_tai_yli_16_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_pidentava_ei_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_pidentava_ei_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_ei_bio_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_ei_bio_pidentava_ok($1)
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Biojäte'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Biojäte'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Biojäte'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Kartonki'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Kartonki'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Kartonki'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Metalli'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Metalli'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Metalli'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Lasi'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Lasi'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Lasi'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Muovi'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Muovi'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Muovi'
+                )   
+            )
+        )
+    );   
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_vaara_tvali_bio_voimassa(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_4_vk_ei_bio
+            FROM jkr.kohteet_joilla_seka_yli_4_vk_ei_bio($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_0_tai_yli_16_vk
+            FROM jkr.kohteet_joilla_seka_0_tai_yli_16_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_pidentava_ei_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_pidentava_ei_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_ei_bio_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_ei_bio_pidentava_ok($1)
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Biojäte'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Biojäte'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Biojäte'
+                )   
+            )
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_vaara_tvali_kompostointi_voimassa(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_4_vk_ei_bio
+            FROM jkr.kohteet_joilla_seka_yli_4_vk_ei_bio($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_0_tai_yli_16_vk
+            FROM jkr.kohteet_joilla_seka_0_tai_yli_16_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_pidentava_ei_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_pidentava_ei_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_ei_bio_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_ei_bio_pidentava_ok($1)
+        )
+    )
+    AND k.id IN (
+        SELECT kohteet_joilla_kompostointi_voimassa
+        FROM jkr.kohteet_joilla_kompostointi_voimassa($1)
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_seka_vaara_tvali(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    (
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_4_vk_ei_bio
+            FROM jkr.kohteet_joilla_seka_yli_4_vk_ei_bio($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_0_tai_yli_16_vk
+            FROM jkr.kohteet_joilla_seka_0_tai_yli_16_vk($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_pidentava_ei_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_pidentava_ei_ok($1)
+        ) OR
+        k.id IN (
+            SELECT kohteet_joilla_seka_yli_16_vk_ei_bio_pidentava_ok
+            FROM jkr.kohteet_joilla_seka_yli_16_vk_ei_bio_pidentava_ok($1)
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_bio_vaara_tvali_seka_voimassa(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    k.id IN (
+        SELECT kohteet_joilla_bio_0_tai_yli_4_vk
+        FROM jkr.kohteet_joilla_bio_0_tai_yli_4_vk($1)
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Sekajäte'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Sekajäte'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Sekajäte'
+                )   
+            )
+        )
+    );
+$$
+LANGUAGE SQL STABLE;
+
+CREATE OR REPLACE FUNCTION jkr.kohteet_joilla_bio_vaara_tvali_muut_voimassa(date) RETURNS TABLE (kohde_id integer) AS
+$$
+SELECT DISTINCT k.id
+FROM
+    jkr.kohde k
+WHERE
+    k.id IN (
+        SELECT kohteet_joilla_bio_0_tai_yli_4_vk
+        FROM jkr.kohteet_joilla_bio_0_tai_yli_4_vk($1)
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Sekajäte'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Sekajäte'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Sekajäte'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Kartonki'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Kartonki'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Kartonki'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Metalli'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Metalli'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Metalli'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Lasi'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Lasi'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Lasi'
+                )   
+            )
+        )
+    )
+    AND (
+        EXISTS (
+            SELECT 1
+            FROM jkr.sopimus s
+            WHERE s.kohde_id = k.id
+            AND s.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE s.jatetyyppi_id = jt.id
+                AND jt.selite = 'Muovi'
+            )
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM jkr.sopimus sk
+            WHERE sk.kohde_id = k.id
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.sopimustyyppi st
+                WHERE sk.sopimustyyppi_id = st.id
+                AND st.selite = 'Kimppasopimus'
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM jkr_koodistot.jatetyyppi jt
+                WHERE sk.jatetyyppi_id = jt.id
+                AND jt.selite = 'Muovi'
+            )
+            AND sk.voimassaolo @> $1
+            AND EXISTS (
+                SELECT 1
+                FROM jkr.sopimus ski
+                WHERE ski.kohde_id = sk.kimppaisanta_kohde_id
+                AND ski.voimassaolo @> $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM jkr_koodistot.jatetyyppi jt
+                    WHERE ski.jatetyyppi_id = jt.id
+                    AND jt.selite = 'Muovi'
+                )   
+            )
+        )
+    );
+$$
+LANGUAGE SQL STABLE;


### PR DESCRIPTION
Lisätään puuttuvat velvoiteyhteenvedot määrittely-excelin riveiltä 33-48.

- lisätty 15 ehtojoukkoa (puuttuvat sekajätteet oli jo valmiina)
- lisätty tarvittavat näkymät erilliskeräysalueiden ulkopuolisista kohteista
- lisätty velvoitemallit

Ei sisällä testejä. Funktiot on testattu pintapuolisesti kannassa. Lisäksi testattu, että kaikki kohteita sisältävät yhteenvedot piirtyvät QGIS:ssä.