### PR TITLE
Lah 573/upload kohdentumattomat to sharepoint

### DIFF
--- a/jkrimporter/__init__.py
+++ b/jkrimporter/__init__.py
@@ -8,6 +8,7 @@ import sys
 from datetime import datetime
 
 __version__ = "0.7.7"
+__log_path__ = "output/jkr.log"
 
 # ---------------------------------------------------------------------------
 # Custom log level: IMPORT (between INFO=20 and WARNING=30)
@@ -138,7 +139,7 @@ logFormatter = logging.Formatter("%(asctime)s [%(levelname)s]  %(message)s")
 rootLogger = logging.getLogger()
 rootLogger.setLevel(_log_level)
 
-fileHandler = logging.FileHandler("output/jkr.log")
+fileHandler = logging.FileHandler(__log_path__)
 fileHandler.setFormatter(logFormatter)
 fileHandler.setLevel(logging.DEBUG)
 rootLogger.addHandler(fileHandler)

--- a/jkrimporter/__init__.py
+++ b/jkrimporter/__init__.py
@@ -138,7 +138,7 @@ logFormatter = logging.Formatter("%(asctime)s [%(levelname)s]  %(message)s")
 rootLogger = logging.getLogger()
 rootLogger.setLevel(_log_level)
 
-fileHandler = logging.FileHandler("jkr.log")
+fileHandler = logging.FileHandler("output/jkr.log")
 fileHandler.setFormatter(logFormatter)
 fileHandler.setLevel(logging.DEBUG)
 rootLogger.addHandler(fileHandler)

--- a/jkrimporter/api/api.py
+++ b/jkrimporter/api/api.py
@@ -58,6 +58,7 @@ from jkrimporter.api.auth import (
     validate_ws_token,
 )
 from jkrimporter.api.util import FileInfo
+from jkrimporter.__init__ import __log_path__
 
 # ---------------------------------------------------------------------------
 # Logging (käyttää jkrimporter.__init__:ssä konfiguroitua root loggeria)
@@ -317,6 +318,16 @@ async def _run_task(task_id: str, command: str, cwd: Optional[str] = None):
         task.status,
         task.duration_seconds or 0,
     )
+
+    log_path = Path(__log_path__)
+    if log_path.exists() and log_path.stat().st_size > 0:
+        try:
+            log_content = log_path.read_bytes()
+            await sp.upload_file(file_content=log_content, filename=log_path.name, user_name="jkr-core")
+            log_path.write_bytes(b"")
+            logger.info("Lokitiedosto lähetetty SharePointiin ja tyhjennetty.")
+        except Exception:
+            logger.exception("Lokitiedoston SharePoint-lähetys epäonnistui.")
 
 
 # ---------------------------------------------------------------------------

--- a/jkrimporter/api/sharepoint.py
+++ b/jkrimporter/api/sharepoint.py
@@ -326,7 +326,10 @@ async def upload_file(
     """
     token = await _get_app_token()
     folder_path = _resolve_folder_path(folder, default=SHAREPOINT_OUTPUT_FOLDER)
-    target = f"{folder_path}/{filename}"
+    stem, _, ext = filename.rpartition(".")
+    timestamp = datetime.now().strftime("%Y%m%d%H%M")
+    stamped = f"{stem}_{timestamp}.{ext}" if stem else f"{filename}_{timestamp}"
+    target = f"{folder_path}/{stamped}"
 
     if len(file_content) < 4 * 1024 * 1024:
         result = await _upload_small(token, target, file_content)

--- a/jkrimporter/providers/db/dbprovider.py
+++ b/jkrimporter/providers/db/dbprovider.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 import os
+import asyncio
 from collections import defaultdict
 from datetime import datetime, timedelta, date
 from pathlib import Path
@@ -35,6 +36,7 @@ from jkrimporter.utils.kaivotieto import (
     export_kohdentumattomat_kaivotiedon_lopetukset,
 )
 from jkrimporter.utils.progress import Progress
+from jkrimporter.api import sharepoint as sp
 
 from . import codes
 from .codes import get_code_id, init_code_objects, keraysvalinetyypit
@@ -690,6 +692,8 @@ class DbProvider:
 
                     if csv_path and kohdentumattomatRivit > 0:
                         lisaa_lisatieto(f"Kohdentumattomat tiedot ({len(kohdentumattomat)}) kpl eli käynteineen {kohdentumattomatRivit} riviä lisätty CSV-tiedostoon: {csv_path}")
+                        file_content = csv_path.read_bytes()
+                        asyncio.run(sp.upload_file(file_content=file_content, filename=csv_path.name, user_name="jkr-core"))
                     elif kohdentumattomatRivit == 0 and kohdentumattomat:
                         # LIETE-data tai muu data jota ei voitu tallentaa Lahden muodossa
                         lisaa_lisatieto(f"Kohdentumattomia tietoja ({len(kohdentumattomat)}) kpl, tallennetaan erilliseen tiedostoon")
@@ -848,7 +852,7 @@ class DbProvider:
                 f"Tallennetaan kohdentumattomat ilmoitukset ({len(kohdentumattomat)}) tiedostoon"
             )
             export_kohdentumattomat_ilmoitukset(
-                os.path.dirname(ilmoitustiedosto), kohdentumattomat
+                Path(ilmoitustiedosto).parent, kohdentumattomat
             )
 
 
@@ -973,7 +977,7 @@ class DbProvider:
                 f"Tallennetaan kohdentumattomat lieteilmoitukset ({len(kohdentumattomat)}) tiedostoon"
             )
             export_kohdentumattomat_lieteIlmoitukset(
-                os.path.dirname(ilmoitustiedosto), kohdentumattomat
+                Path(ilmoitustiedosto).parent, kohdentumattomat
             )
 
     def write_lopetusilmoitukset(
@@ -1034,7 +1038,7 @@ class DbProvider:
                 f"Tallennetaan kohdentumattomat lopetusilmoitukset ({len(kohdentumattomat)}) tiedostoon"
             )
             export_kohdentumattomat_lopetusilmoitukset(
-                os.path.dirname(ilmoitustiedosto), kohdentumattomat
+                Path(ilmoitustiedosto).parent, kohdentumattomat
             )
 
     def write_paatokset(
@@ -1096,7 +1100,7 @@ class DbProvider:
                 f"Tallennetaan kohdentumattomat päätökset ({len(kohdentumattomat)}) tiedostoon"
             )
             export_kohdentumattomat_paatokset(
-                os.path.dirname(paatostiedosto), kohdentumattomat
+                Path(paatostiedosto).parent, kohdentumattomat
             )
 
     def write_kaivotiedot(
@@ -1196,7 +1200,7 @@ class DbProvider:
         if kohdentumattomat:
             lisaa_lisatieto(f"Tallennetaan kohdentumattomat kaivotiedot ({len(kohdentumattomat)}) tiedostoon")
             export_kohdentumattomat_kaivotiedot(
-                os.path.dirname(kaivotiedosto_path), kohdentumattomat
+                Path(kaivotiedosto_path).parent, kohdentumattomat
             )
 
     def write_kaivotiedon_lopetukset(
@@ -1279,7 +1283,7 @@ class DbProvider:
         if kohdentumattomat:
             lisaa_lisatieto(f"Tallennetaan kohdentumattomat kaivotiedon lopetukset ({len(kohdentumattomat)}) tiedostoon")
             export_kohdentumattomat_kaivotiedon_lopetukset(
-                os.path.dirname(lopetustiedosto_path), kohdentumattomat
+                Path(lopetustiedosto_path).parent, kohdentumattomat
             )
 
     def write_viemariliitos(
@@ -1351,7 +1355,7 @@ class DbProvider:
         if kohdentumattomat:
             lisaa_lisatieto(f"Tallennetaan kohdentumattomat viemäriliitokset ({len(kohdentumattomat)}) tiedostoon")
             export_kohdentumattomat_viemariilmoitukset(
-                os.path.dirname(viemaritiedosto_path), kohdentumattomat, viemaritiedosto_path
+                Path(viemaritiedosto_path).parent, kohdentumattomat, viemaritiedosto_path
             )
 
 
@@ -1422,5 +1426,5 @@ class DbProvider:
         if kohdentumattomat:
             lisaa_lisatieto(f"Tallennetaan kohdentumattomat viemärilopetukset ({len(kohdentumattomat)}) tiedostoon")
             export_kohdentumattomat_viemarilopetusilmoitukset(
-                os.path.dirname(lopetustiedosto_path), kohdentumattomat
+                Path(lopetustiedosto_path).parent, kohdentumattomat
             )

--- a/jkrimporter/providers/lahti/ilmoitustiedosto.py
+++ b/jkrimporter/providers/lahti/ilmoitustiedosto.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 
 from openpyxl.reader.excel import load_workbook
@@ -71,7 +70,7 @@ class Ilmoitustiedosto:
                 failed_validations.append(data)
 
         export_kohdentumattomat_ilmoitukset(
-            os.path.dirname(self._path), failed_validations
+            Path(self._path).parent, failed_validations
         )
 
         return ilmoitus_list
@@ -127,7 +126,7 @@ class LieteIlmoitustiedosto:
                 failed_validations.append(data)
 
         export_kohdentumattomat_lieteIlmoitukset(
-            os.path.dirname(self._path), failed_validations
+            Path(self._path).parent, failed_validations
         )
 
         return ilmoitus_list
@@ -183,7 +182,7 @@ class LopetusIlmoitustiedosto:
                 failed_validations.append(data)
 
         export_kohdentumattomat_lopetusilmoitukset(
-            os.path.dirname(self._path), failed_validations
+            Path(self._path).parent, failed_validations
         )
 
         return lopetus_list

--- a/jkrimporter/providers/lahti/paatostiedosto.py
+++ b/jkrimporter/providers/lahti/paatostiedosto.py
@@ -63,6 +63,6 @@ class Paatostiedosto:
 
         if failed_validations:
             print(f"Päätostiedosto sisältää {len(failed_validations)} virheellistä riviä.")
-            export_kohdentumattomat_paatokset(os.path.dirname(self._path), failed_validations)
+            export_kohdentumattomat_paatokset(Path(self._path).parent, failed_validations)
 
         return paatos_list

--- a/jkrimporter/providers/lahti/viemaritiedosto.py
+++ b/jkrimporter/providers/lahti/viemaritiedosto.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -18,6 +19,7 @@ from jkrimporter.datasheets import (
     get_viemari_ilmoitustiedosto_headers
 )
 from jkrimporter.providers.lahti.models import ViemariIlmoitus, ViemariLopetusIlmoitus
+from jkrimporter.api import sharepoint as sp
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +73,7 @@ class ViemariIlmoitustiedosto:
                 failed_validations.append(data)
 
         export_kohdentumattomat_viemariilmoitukset(
-            os.path.dirname(self._path), failed_validations, self._path
+            Path(self._path).parent, failed_validations, self._path
         )
 
         return lopetus_list
@@ -126,7 +128,7 @@ class ViemariLopetustiedosto:
                 failed_validations.append(data)
 
         export_kohdentumattomat_viemarilopetusilmoitukset(
-            os.path.dirname(self._path), failed_validations
+            Path(self._path).parent, failed_validations
         )
 
         return lopetus_list
@@ -147,11 +149,9 @@ def export_kohdentumattomat_viemariilmoitukset(
 
     print(lahettaja)
 
-    output_file_path_failed = os.path.join(
-        folder, get_kohdentumattomat_viemari_ilmoitus_filename(lahettaja)
-    )
+    output_file_path_failed = folder / get_kohdentumattomat_viemari_ilmoitus_filename(lahettaja)
 
-    if os.path.exists(output_file_path_failed):
+    if output_file_path_failed.exists():
         workbook_failed = openpyxl.load_workbook(output_file_path_failed)
         sheet_failed = workbook_failed[workbook_failed.sheetnames[0]]
     else:
@@ -167,6 +167,9 @@ def export_kohdentumattomat_viemariilmoitukset(
         sheet_failed.append([row.get(header, "") for header in expected_headers])
 
     workbook_failed.save(output_file_path_failed)
+
+    file_content = output_file_path_failed.read_bytes()
+    asyncio.run(sp.upload_file(file_content=file_content, filename=output_file_path_failed.name, user_name="jkr-core"))
 
 
 def export_kohdentumattomat_viemarilopetusilmoitukset(
@@ -175,11 +178,10 @@ def export_kohdentumattomat_viemarilopetusilmoitukset(
 ):
     expected_headers = get_viemari_lopetustiedosto_headers()
 
-    output_file_path_failed = os.path.join(
-        folder, get_kohdentumattomat_viemarin_lopetus_filename()
-    )
+    output_file_path_failed = folder / get_kohdentumattomat_viemarin_lopetus_filename()
+    
 
-    if os.path.exists(output_file_path_failed):
+    if output_file_path_failed.exists():
         workbook_failed = openpyxl.load_workbook(output_file_path_failed)
         sheet_failed = workbook_failed[workbook_failed.sheetnames[0]]
     else:
@@ -195,3 +197,6 @@ def export_kohdentumattomat_viemarilopetusilmoitukset(
         sheet_failed.append([row.get(header, "") for header in expected_headers])
 
     workbook_failed.save(output_file_path_failed)
+    
+    file_content = output_file_path_failed.read_bytes()
+    asyncio.run(sp.upload_file(file_content=file_content, filename=output_file_path_failed.name, user_name="jkr-core"))

--- a/jkrimporter/utils/ilmoitus.py
+++ b/jkrimporter/utils/ilmoitus.py
@@ -1,4 +1,5 @@
 import os
+import asyncio
 from pathlib import Path
 from typing import Dict, List
 
@@ -14,6 +15,7 @@ from jkrimporter.datasheets import (
     get_liete_ilmoitustiedosto_headers,
     get_lopetustiedosto_headers,
 )
+from jkrimporter.api import sharepoint as sp
 
 
 def export_kohdentumattomat_ilmoitukset(
@@ -22,11 +24,9 @@ def export_kohdentumattomat_ilmoitukset(
 ):
     expected_headers = get_ilmoitustiedosto_headers()
 
-    output_file_path_failed = os.path.join(
-        folder, get_kohdentumattomat_ilmoitus_filename()
-    )
+    output_file_path_failed = folder / get_kohdentumattomat_ilmoitus_filename()
 
-    if os.path.exists(output_file_path_failed):
+    if output_file_path_failed.exists():
         workbook_failed = openpyxl.load_workbook(output_file_path_failed)
         sheet_failed = workbook_failed[workbook_failed.sheetnames[0]]
     else:
@@ -63,17 +63,18 @@ def export_kohdentumattomat_ilmoitukset(
 
     workbook_failed.save(output_file_path_failed)
 
+    file_content = output_file_path_failed.read_bytes()
+    asyncio.run(sp.upload_file(file_content=file_content, filename=output_file_path_failed.name, user_name="jkr-core"))
+
 def export_kohdentumattomat_lieteIlmoitukset(
         folder: Path,
         kohdentumattomat: List[Dict[str, str]]
 ):
     expected_headers = get_liete_ilmoitustiedosto_headers()
 
-    output_file_path_failed = os.path.join(
-        folder, get_kohdentumattomat_lieteilmoitus_filename()
-    )
+    output_file_path_failed = folder / get_kohdentumattomat_lieteilmoitus_filename()
 
-    if os.path.exists(output_file_path_failed):
+    if output_file_path_failed.exists():
         workbook_failed = openpyxl.load_workbook(output_file_path_failed)
         sheet_failed = workbook_failed[workbook_failed.sheetnames[0]]
     else:
@@ -89,6 +90,9 @@ def export_kohdentumattomat_lieteIlmoitukset(
         sheet_failed.append([row.get(header, "") for header in expected_headers])
 
     workbook_failed.save(output_file_path_failed)
+
+    file_content = output_file_path_failed.read_bytes()
+    asyncio.run(sp.upload_file(file_content=file_content, filename=output_file_path_failed.name, user_name="jkr-core"))
 
 
 def export_kohdentumattomat_lopetusilmoitukset(
@@ -97,11 +101,10 @@ def export_kohdentumattomat_lopetusilmoitukset(
 ):
     expected_headers = get_lopetustiedosto_headers()
 
-    output_file_path_failed = os.path.join(
-        folder, get_kohdentumattomat_lopetusilmoitus_filename()
-    )
+    output_file_path_failed = folder / get_kohdentumattomat_lopetusilmoitus_filename()
+    
 
-    if os.path.exists(output_file_path_failed):
+    if output_file_path_failed.exists():
         workbook_failed = openpyxl.load_workbook(output_file_path_failed)
         sheet_failed = workbook_failed[workbook_failed.sheetnames[0]]
     else:
@@ -117,3 +120,6 @@ def export_kohdentumattomat_lopetusilmoitukset(
         sheet_failed.append([row.get(header, "") for header in expected_headers])
 
     workbook_failed.save(output_file_path_failed)
+
+    file_content = output_file_path_failed.read_bytes()
+    asyncio.run(sp.upload_file(file_content=file_content, filename=output_file_path_failed.name, user_name="jkr-core"))

--- a/jkrimporter/utils/kaivotieto.py
+++ b/jkrimporter/utils/kaivotieto.py
@@ -6,10 +6,11 @@ LAH-415: Kaivotiedot ja kaivotiedon lopetus tietojen vienti kantaan.
 
 import csv
 import logging
-import os
+import asyncio
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Union
+from jkrimporter.api import sharepoint as sp
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,8 @@ def export_kohdentumattomat_kaivotiedot(
         writer.writeheader()
         writer.writerows(kohdentumattomat)
     
+    file_content = filepath.read_bytes()
+    asyncio.run(sp.upload_file(file_content=file_content, filename=filepath.name, user_name="jkr-core"))
     logger.info(f"Kohdentumattomat kaivotiedot ({len(kohdentumattomat)} kpl) tallennettu: {filepath}")
     
     return filepath

--- a/jkrimporter/utils/liete.py
+++ b/jkrimporter/utils/liete.py
@@ -2,16 +2,18 @@
 LIETE-aineiston apufunktiot.
 """
 
+import asyncio
 import csv
 import logging
 from pathlib import Path
 from typing import List, Dict, Any
+from jkrimporter.api import sharepoint as sp
 
 logger = logging.getLogger(__name__)
 
 
 def export_kohdentumattomat_liete_kuljetukset(
-    output_dir: str, 
+    output_dir: str,
     kohdentumattomat: List[Dict[str, Any]]
 ) -> None:
     """
@@ -72,6 +74,8 @@ def export_kohdentumattomat_liete_kuljetukset(
                     row_dict = {k: str(v) if v is not None else '' for k, v in row_dict.items()}
                     writer.writerow(row_dict)
         
+        file_content = output_path.read_bytes()
+        asyncio.run(sp.upload_file(file_content=file_content, filename=output_path.name, user_name="jkr-core"))
         logger.info(f"Tallennettu {len(kohdentumattomat)} kohdentamatonta LIETE-kuljetusta tiedostoon: {output_path}")
         print(f"Kohdentamattomat LIETE-kuljetukset ({len(kohdentumattomat)} kpl) tallennettu: {output_path}")
         

--- a/jkrimporter/utils/paatos.py
+++ b/jkrimporter/utils/paatos.py
@@ -1,21 +1,20 @@
-import os
 from pathlib import Path
 from typing import Dict, List
+import asyncio
 
 import openpyxl
 
 from jkrimporter.conf import get_kohdentumattomat_paatos_filename
 from jkrimporter.datasheets import get_paatostiedosto_headers
+from jkrimporter.api import sharepoint as sp
 
 
 def export_kohdentumattomat_paatokset(folder: Path, kohdentumattomat: List[Dict[str, str]]):
     expected_headers = get_paatostiedosto_headers()
 
-    output_file_path_failed = os.path.join(
-        folder, get_kohdentumattomat_paatos_filename()
-    )
+    output_file_path_failed = folder / get_kohdentumattomat_paatos_filename()
 
-    if os.path.exists(output_file_path_failed):
+    if output_file_path_failed.exists():
         workbook_failed = openpyxl.load_workbook(output_file_path_failed)
         sheet_failed = workbook_failed[workbook_failed.sheetnames[0]]
     else:
@@ -31,3 +30,6 @@ def export_kohdentumattomat_paatokset(folder: Path, kohdentumattomat: List[Dict[
         sheet_failed.append([row.get(header, "") for header in expected_headers])
 
     workbook_failed.save(output_file_path_failed)
+
+    file_content = output_file_path_failed.read_bytes()
+    asyncio.run(sp.upload_file(file_content=file_content, filename=output_file_path_failed.name, user_name="jkr-core"))


### PR DESCRIPTION
- Send kohdentumaton file to sharepoint once it is ready
- Send log to sharepoint at the end of each task and truncate it afterwards to ensure smaller file sizes and avoid unnecessary duplication